### PR TITLE
use Number::Phone::JP via Number::Phone

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,6 +3,7 @@ name 'Number-Phone-JP';
 all_from 'lib/Number/Phone/JP.pm';
 
 build_requires 'Test::More';
+build_requires 'Test::Requires';
 requires 'UNIVERSAL::require' => 0;
 author_tests 'xt';
 WriteAll;

--- a/lib/Number/Phone/JP.pm
+++ b/lib/Number/Phone/JP.pm
@@ -60,6 +60,17 @@ sub set_number {
         $self->_prefix = $pref;
         $self->_number = $num;
     }
+    elsif ($number =~ s/^\+81//) {
+        $self->_prefix = ();
+        $self->_number = ();
+        for (my $i = 1; $i < length $number; $i++) {
+            my $pref = substr $number, 0, $i;
+            if ($TEL_TABLE{$pref}) {
+                $self->_prefix = "0$pref";
+                $self->_number = substr $number, $i;
+            }
+        }
+    }
     else {
         carp "The number is invalid telephone number.";
         $self->_prefix = ();
@@ -83,6 +94,11 @@ sub is_valid_number {
 
 sub _prefix : lvalue { shift->{_prefix} }
 sub _number : lvalue { shift->{_number} }
+
+{
+    no warnings 'once';
+    *is_valid = \&is_valid_number;
+}
 
 1;
 __END__

--- a/t/number-phone.t
+++ b/t/number-phone.t
@@ -1,0 +1,16 @@
+use strict;
+use Test::More tests => 1 + 11;
+use Test::Requires qw( Number::Phone );
+use_ok('Number::Phone::JP');
+
+ok(Number::Phone->new('+810112345678')->is_valid, 'checking for 001 12345678');
+ok(Number::Phone->new('+810912012345678')->is_valid, 'checking for 009120 12345678');
+ok(Number::Phone->new('+816033001234')->is_valid, 'checking for 060 33001234');
+ok(Number::Phone->new('+81120000123')->is_valid, 'checking for 0120 000123');
+ok(Number::Phone->new('+81112001234')->is_valid, 'checking for 011 2001234');
+ok(Number::Phone->new('+815010001234')->is_valid, 'checking for 050 10001234');
+ok(Number::Phone->new('+818010012345')->is_valid, 'checking for 080 10012345');
+ok(Number::Phone->new('+812046012345')->is_valid, 'checking for 020 46012345');
+ok(Number::Phone->new('+817050112345')->is_valid, 'checking for 070 50112345');
+ok(Number::Phone->new('+81990500123')->is_valid, 'checking for 0990 500123');
+ok(Number::Phone->new('+81570000123')->is_valid, 'checking for 0570 000123');


### PR DESCRIPTION
Number::Phone使おうとしてるのだけど、Number::Phoneいけてないところがあって、
use Number::Phone::国コード; を勝手にするのですよね。

なので、おそらく既知だと思いますが、

+81な番号をNumber::Phone->newに渡した場合、Number::Phone::JPが入ってる環境の場合
Number::Phone::JP->newにその番号を渡した結果が返ってきます。

で、Number::Phone::JPの方は国番号なし、市外局番とその他が分かれたものを受け取る前提なので、
The number is invalid telephone number.
と言われてしまいます。

なので、以下をやった時点のpull requrestです
- 国番号切って、市外局番をがんばって探すのを追加
- Number::Phoneに合わせてis_validをis_valid_numberのエイリアスとして追加

以下はやってません
- ドキュメント
